### PR TITLE
chore(CHANGELOG): no CI on changelog generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,7 @@ gulp.task('commit-changes', () =>
   gulp
     .src('.')
     .pipe(git.add())
-    .pipe(git.commit(`docs(CHANGELOG): bumping version to ${version()}`))
+    .pipe(git.commit(`docs(CHANGELOG): bumping version to ${version()} [skip ci]`))
 );
 
 gulp.task('push-changes', done =>


### PR DESCRIPTION
generating a new changelog should not trigger a new build process on travis. It cost too much
resources and throttles the Coveo team for travis CI.

closes #10